### PR TITLE
Fix tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,15 +27,14 @@ jobs:
           background: true
 
       - run:
-          name: "Start Trufflepig"
-          command: |
-            cd src/lib/colonyNetwork
-            ../../../node_modules/.bin/trufflepig --ganacheKeyFile ganache-accounts.json -v
-          background: true
+          name: "Deploy contracts"
+          command: yarn run deploy-contracts
 
       - run:
-          name: "Compile contracts"
-          command: yarn run deploy-contracts
+          name: "Start Trufflepig"
+          command: |
+            scripts/ci_trufflepig.js
+          background: true
 
       - run: |
           $HOME/.config/yarn/global/node_modules/.bin/greenkeeper-lockfile-update

--- a/scripts/ci_trufflepig.js
+++ b/scripts/ci_trufflepig.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+// This file is only for use on Continuous Integration platforms and does not contribute to the example code itself
+
+const path = require('path');
+const TrufflePig = require('trufflepig');
+
+const trufflePigOptions = {
+  contractDir: path.resolve(__dirname, '..', 'src', 'lib', 'colonyNetwork', 'build', 'contracts'),
+  ganacheKeyFile: path.resolve(__dirname, '..', 'src', 'lib', 'colonyNetwork', 'ganache-accounts.json'),
+  verbose: true,
+};
+
+const trufflePigServer = new TrufflePig(trufflePigOptions);
+
+trufflePigServer.on('ready', rd => console.log('Truffle pig is ready'))
+trufflePigServer.on('error', err => console.log(err))
+trufflePigServer.on('log', log => console.log(log))
+
+trufflePigServer.start();


### PR DESCRIPTION
This adds a programmatically invoked version of trufflepig because CirclCI does not support its great(!) user interface.